### PR TITLE
Add option to allow self signed server certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ the task at hand.
 	Then find the `My Account` button in the top-right corner.
 	On the right side click on `Show` under `API access key`.
 	Copy the key and place it to your installation setup script.
+- `insecure`: allow curl to use insecure server connections, default is `false`
 
 ## Lazy
 
@@ -32,6 +33,7 @@ the task at hand.
 		require('angerona').setup({
 			api_key = "<API_KEY>",
 			base_url = "https://redmine.emlix.com",
+            insecure = false,
 	})
 	end
 }

--- a/lua/angerona/http.lua
+++ b/lua/angerona/http.lua
@@ -5,6 +5,7 @@ local http = require("plenary.curl")
 M.headers = nil
 M.url = nil
 M.end_point = nil
+M.insecure = false
 
 local function query(method, path, body)
 	local url = M.base_url .. "/" .. M.end_point
@@ -19,6 +20,7 @@ local function query(method, path, body)
 		method = method,
 		headers = M.headers,
 		body = vim.fn.json_encode(body),
+		insecure = M.insecure,
 	})
 
 	if response.status == 200 or response.status == 201 or response.status == 204 then
@@ -51,6 +53,9 @@ function M.setup(config, end_point)
 		["X-Redmine-API-Key"] = config.api_key,
 	}
 	M.end_point = end_point
+	if config.insecure ~= nil then
+		M.insecure = config.insecure
+	end
 
 	return M
 end


### PR DESCRIPTION
Add the insecure option to allow curl to request also redmine instances with self signed certificates (internal company networks etc.). This option is false by default and can be adjusted in plugins configuration.